### PR TITLE
Patch job delete functionality and fix text styling issue

### DIFF
--- a/src/components/JobListing.tsx
+++ b/src/components/JobListing.tsx
@@ -23,9 +23,11 @@ function JobListing({ job }: { job: Job }) {
 
         <div className="mb-5">{description}</div>
 
+
         <button
           onClick={() => setShowFullDescription(prevState => !prevState)}
           className="text-indigo-500 mb-5 hover:text-indigo-600"
+          hidden={!(description.length > 90)}
         >
           {showFullDescription ? 'Less' : 'More'}
         </button>

--- a/src/components/JobListing.tsx
+++ b/src/components/JobListing.tsx
@@ -1,7 +1,7 @@
-import { useState } from "react";
-import { Job } from "../types/Job";
-import { FaMapMarker } from "react-icons/fa";
-import { Link } from "react-router-dom";
+import { useState } from 'react';
+import { Job } from '../types/Job';
+import { FaMapMarker } from 'react-icons/fa';
+import { Link } from 'react-router-dom';
 
 function JobListing({ job }: { job: Job }) {
   const [showFullDescription, setShowFullDescription] = useState(false);
@@ -9,7 +9,8 @@ function JobListing({ job }: { job: Job }) {
   let description = job.description;
 
   if (!showFullDescription) {
-    description = description.substring(0, 90) + "...";
+    description =
+      description.substring(0, 90) + (description.length > 90) ? '...' : '';
   }
 
   return (
@@ -23,10 +24,10 @@ function JobListing({ job }: { job: Job }) {
         <div className="mb-5">{description}</div>
 
         <button
-          onClick={() => setShowFullDescription((prevState) => !prevState)}
+          onClick={() => setShowFullDescription(prevState => !prevState)}
           className="text-indigo-500 mb-5 hover:text-indigo-600"
         >
-          {showFullDescription ? "Less" : "More"}
+          {showFullDescription ? 'Less' : 'More'}
         </button>
 
         <h3 className="text-indigo-500 mb-2">{job.salary} / Year</h3>

--- a/src/pages/JobPage.tsx
+++ b/src/pages/JobPage.tsx
@@ -14,7 +14,7 @@ const JobPage = ({ deleteJob }: { deleteJob: DeleteJobAction }) => {
 
     if (!confirm) return;
 
-    deleteJob("id" + id);
+    deleteJob(id);
 
     toast.success("Job Deleted Successfully!");
 


### PR DESCRIPTION
Apparently some programmers have this little mistake:
1. Bug: Unable to delete a job listing.
2. Feature change: Job listing card will show at max 90 characters before cutting it off and appending "..." characters into it. However, job listing with less than or equal to 90 characters will still have these characters appended. Make it so these three characters **and** "More" button didn't show if the description is less than 90 characters.

so to address the issue, I do a couple of things:
1. Remove `id` text
2. Hide the button when the text is lower than 90 and display ... only when the text is greater than 90

![image](https://github.com/user-attachments/assets/b84898d7-8dd8-4150-9ca9-b649fa34344a)

